### PR TITLE
Support ^N and ^P

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -398,7 +398,7 @@ pub fn input(isolate: &mut Isolate) -> Result<String, InputError> {
                             mode = InputMode::Completion(new);
                         }
                     }
-                    Event::Key(Key::Up) => {
+                    Event::Key(Key::Up) | Event::Key(Key::Ctrl('p')) => {
                         match &mut mode {
                             InputMode::Normal => {
                                 history.prev(user_input.as_str());
@@ -412,7 +412,7 @@ pub fn input(isolate: &mut Isolate) -> Result<String, InputError> {
                             }
                         }
                     }
-                    Event::Key(Key::Down) => {
+                    Event::Key(Key::Down) | Event::Key(Key::Ctrl('n')) => {
                         match &mut mode {
                             InputMode::Normal => {
                                 history.next();


### PR DESCRIPTION
Some of bash/zsh/fish users use `^N` as ↓ key and `^P` as ↑ key.
Adding these shortcuts will improve `nsh`'s UX (at least, macos users and emacs users may love these features).

Thank you for your great project!