### PR TITLE
This (simple) PR makes it possible to BackTab (shift+tab) while in completion mode.

### DIFF
--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -299,7 +299,7 @@ impl Mainloop {
 
         let mut needs_redraw = true;
         match (ev.code, ev.modifiers) {
-            (KeyCode::Left, NONE) if self.completion_mode() => {
+            (KeyCode::Left, NONE) | (KeyCode::BackTab, SHIFT) if self.completion_mode() => {
                 self.comp_selected = self.comp_selected.saturating_sub(1);
             }
             (KeyCode::Right, NONE) | (KeyCode::Tab, NONE)


### PR DESCRIPTION
Hi.

While tabbing my way through completions, I was unable to shift back (back tab) as I'm used to. This PR adds the keybinding <kbd>shift</kbd>+<kbd>tab</kbd> in completion_mode. 

As I understand it, the guard 'if self.completion_mode()' is repeated for both patterns, but I might be wrong. I have very little experience with Rust and low-level languages in general. I glanced the manual regarding [match expression](https://doc.rust-lang.org/reference/expressions/match-expr.html), but I found it a bit confusing, so I'm hoping you can confirm that this PR causes no side effects.


