### PR TITLE
Fix remove_until_word_start in case the only remaining character left is a whitespace character and the cursor is already on 0th position

### DIFF
--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -1118,7 +1118,7 @@ impl UserInput {
     pub fn remove_until_word_start(&mut self) {
         // Remove whitespaces and slashes.
         while let Some(ch) = self.nth(self.cursor.saturating_sub(1)) {
-            if !self.word_split.contains(ch) {
+            if self.cursor == 0 || !self.word_split.contains(ch) {
                 break;
             }
 


### PR DESCRIPTION
Fixes remove_until_word_start in case the only remaining character(s) left is a whitespace character and the cursor is already on 0th position