### PR TITLE
Fix pattern matching when already sitting in the directory that is defined with absolute value in the searched pattern

### DIFF
--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -1210,6 +1210,8 @@ fn path_completion(pattern: &str, only_dirs: bool) -> FuzzyVec {
 
                 let (prefix, relpath) = if pattern.starts_with('~') {
                     ("~/", path.strip_prefix(&home_dir).unwrap())
+                } else if pattern.starts_with("/") {
+                    ("/", path.strip_prefix("/").unwrap())
                 } else {
                     ("", path.strip_prefix(&current_dir).unwrap_or(&path))
                 };


### PR DESCRIPTION
When located in the directory (e.g. `/etc`) then absolute location pattern matching for that single directory doesn't work as expected. Example:

Located in home directory (works fine):

![in_home](https://user-images.githubusercontent.com/63632594/140095089-c971a9d4-2433-4a35-8bef-58f8b6c0446d.png)

vs located in `/etc` (`/etc` is expected to be in the results, but is not):

![in_etc](https://user-images.githubusercontent.com/63632594/140095106-ccf773ac-3ba4-4a7b-8596-07e6d34ab17a.png)