### PR TITLE
Fix clippy warning

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -278,7 +278,7 @@ impl Shell {
         &mut self.jobs
     }
 
-    #[warn(clippy::mutable_key_type)]
+    #[allow(clippy::mutable_key_type)]
     pub fn background_jobs_mut(&mut self) -> &mut HashSet<Rc<Job>> {
         &mut self.background_jobs
     }


### PR DESCRIPTION
I introduced this via #32. My bad.
It was the last warning so I didn't run clippy again.