### PR TITLE
implement (naive) `exec` builtin command

### DIFF
--- a/src/builtins/exec.rs
+++ b/src/builtins/exec.rs
@@ -21,7 +21,7 @@ pub fn command(ctx: &mut InternalCommandContext) -> ExitStatus {
         {
             Ok(args) => args,
             Err(_) => {
-                writeln!(ctx.stderr, "nsh: exec: nul found in inputs").ok();
+                writeln!(ctx.stderr, "nsh: exec: invalid command (perhaps it includes a NUL character?)").ok();
                 return ExitStatus::Return;
             }
         };

--- a/src/builtins/exec.rs
+++ b/src/builtins/exec.rs
@@ -1,0 +1,47 @@
+use crate::builtins::InternalCommandContext;
+use crate::process::ExitStatus;
+use nix::errno::Errno;
+use std::ffi::CString;
+use std::io::Write;
+
+pub fn command(ctx: &mut InternalCommandContext) -> ExitStatus {
+    if let Some(command) = ctx.argv.get(1) {
+        let command = match CString::new(command.as_bytes()) {
+            Ok(args) => args,
+            Err(_) => {
+                writeln!(ctx.stderr, "nsh: exec: nul found in inputs").ok();
+                return ExitStatus::Return;
+            }
+        };
+        // args should include `command`
+        let args = match ctx.argv[1..]
+            .into_iter()
+            .map(|s| CString::new(s.as_bytes()))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(args) => args,
+            Err(_) => {
+                writeln!(ctx.stderr, "nsh: exec: nul found in inputs").ok();
+                return ExitStatus::Return;
+            }
+        };
+
+        match nix::unistd::execvp(&command, &args) {
+            Ok(never) => match never {},
+            Err(e) => {
+                writeln!(ctx.stderr, "nsh: exec: {}", e).ok();
+                let code = match e {
+                    // file not executable
+                    Errno::ENOEXEC | Errno::EACCES | Errno::EINVAL => 126,
+                    // file not found
+                    Errno::ENOENT => 127,
+                    _ => 1,
+                };
+                ExitStatus::ExitedWith(code)
+            }
+        }
+    } else {
+        // do nothing for now
+        ExitStatus::ExitedWith(0)
+    }
+}

--- a/src/builtins/exec.rs
+++ b/src/builtins/exec.rs
@@ -9,7 +9,7 @@ pub fn command(ctx: &mut InternalCommandContext) -> ExitStatus {
         let command = match CString::new(command.as_bytes()) {
             Ok(args) => args,
             Err(_) => {
-                writeln!(ctx.stderr, "nsh: exec: nul found in inputs").ok();
+                writeln!(ctx.stderr, "nsh: exec: invalid command (perhaps it includes a NUL character?)").ok();
                 return ExitStatus::Return;
             }
         };

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -9,6 +9,7 @@ mod bg;
 mod cd;
 mod echo;
 mod eval;
+mod exec;
 mod exit;
 mod export;
 mod fg;
@@ -55,6 +56,7 @@ pub static INTERNAL_COMMANDS: phf::Map<&'static str, InternalCommand> = phf_map!
     "cd" => crate::builtins::cd::command,
     "source" => crate::builtins::source::command,
     "exit" => crate::builtins::exit::command,
+    "exec" => crate::builtins::exec::command,
     "export" => crate::builtins::export::command,
     "set" => crate::builtins::set::command,
     "fg" => crate::builtins::fg::command,

--- a/test/exec.sh
+++ b/test/exec.sh
@@ -1,0 +1,3 @@
+echo "exec echo exec"
+exec echo exec
+echo "unreachable"

--- a/test/exec.stdout
+++ b/test/exec.stdout
@@ -1,0 +1,2 @@
+exec echo exec
+exec


### PR DESCRIPTION
This P-R partially implements `exec` command. It only supports `exec cat maggie` syntax and doesn't `exec 3< readfile`.

See also https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exec