### PR TITLE
Multibyte character problem fix

### DIFF
--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -1001,7 +1001,7 @@ impl UserInput {
     }
 
     pub fn replace_range(&mut self, range: Range<usize>, replace_with: &str) {
-        let cursor = range.start + replace_with.len();
+        let cursor = range.start + replace_with.chars().count();
         self.input.replace_range(range, replace_with);
         self.update_indices();
         self.cursor = cursor;


### PR DESCRIPTION
Fixes #34

This fixes the crash, but there still are problems with the display of the cursor. A refactor using something like [unicode-segmentation](https://crates.io/crates/unicode-segmentation) would probably fix the problems, since it allows handling graphemes instead of chars.